### PR TITLE
Doppelter Honigeintopf. Getrennt für next Pach

### DIFF
--- a/DE/Game.po
+++ b/DE/Game.po
@@ -7473,7 +7473,7 @@ msgstr "Eintopf"
 #: /Game/LocalizationText/ItemInfo.ItemInfo
 msgctxt "ItemInfo,F31"
 msgid "蜜汁炖菜"
-msgstr "Honigeintopf"
+msgstr "Eintopf mit Honig"
 
 #. Key:	F32
 #. SourceLocation:	/Game/LocalizationText/ItemInfo.ItemInfo


### PR DESCRIPTION
Honigeintopf mit dem Namen getrennt, dann kann man beim nächsten Patch ggf. wenn nötig die Rezepte richten.